### PR TITLE
Link NVSHMEM to sublibraries as interface

### DIFF
--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -68,7 +68,7 @@ target_link_libraries(pplx_kernels PUBLIC
     Python::Module
     CUDA::cuda_driver
     CUDA::cudart
-    nvshmem::nvshmem_host
+    nvshmem::nvshmem
 )
 set_target_properties(pplx_kernels PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../src/pplx_kernels

--- a/csrc/all_to_all/CMakeLists.txt
+++ b/csrc/all_to_all/CMakeLists.txt
@@ -15,9 +15,12 @@ add_library(all_to_all_intranode_lib STATIC
 )
 target_link_libraries(all_to_all_intranode_lib PUBLIC
     all_to_all_common
-    nvshmem::nvshmem
     CUDA::cudart
 )
+target_link_libraries(all_to_all_intranode_lib INTERFACE
+    nvshmem::nvshmem
+)
+target_include_directories(all_to_all_intranode_lib PRIVATE ${NVSHMEM_INCLUDE_DIR})
 set_cuda_compile_options(all_to_all_intranode_lib)
 
 add_library(all_to_all_internode_lib STATIC
@@ -27,9 +30,12 @@ add_library(all_to_all_internode_lib STATIC
 )
 target_link_libraries(all_to_all_internode_lib PUBLIC
     all_to_all_common
-    nvshmem::nvshmem
     CUDA::cudart
 )
+target_link_libraries(all_to_all_internode_lib INTERFACE
+    nvshmem::nvshmem
+)
+target_include_directories(all_to_all_internode_lib PRIVATE ${NVSHMEM_INCLUDE_DIR})
 set_cuda_compile_options(all_to_all_internode_lib)
 
 if(WITH_TESTS)

--- a/csrc/core/CMakeLists.txt
+++ b/csrc/core/CMakeLists.txt
@@ -6,6 +6,9 @@ add_library(core_lib STATIC
 )
 target_link_libraries(core_lib PUBLIC
     CUDA::cudart
+)
+target_link_libraries(core_lib INTERFACE
     nvshmem::nvshmem
 )
+target_include_directories(core_lib PRIVATE ${NVSHMEM_INCLUDE_DIR})
 set_cuda_compile_options(core_lib)


### PR DESCRIPTION
Without this change `all_to_all_internode_lib`, `all_to_all_intranode_lib` and `core_lib` link NVSHMEM in such way that external variables of NVSHMEM have multiple instances, e.g.:
```
&nvshmemi_device_state = 0x7d5121b1fb20
nvshmemi_device_state.nvshmemi_is_nvshmem_initialized = 1
&nvshmemi_device_state = 0x7d511a7c22e0
nvshmemi_device_state.nvshmemi_is_nvshmem_initialized = 0
```
which leads to unpredictable errors like:
```
NVSHMEM API called before NVSHMEM initialization has completed
```

@nandor @abcdabcd987
