### PR TITLE
Fix the usage of meta information 

### DIFF
--- a/csrc/all_to_all/internode_dispatch.cu
+++ b/csrc/all_to_all/internode_dispatch.cu
@@ -212,11 +212,11 @@ __global__ __launch_bounds__(NUM_WARPS * 32, 1) void dispatchKernel(
       for (unsigned i = threadIdx.x; i < numTokens; i += blockDim.x) {
         std::byte *xTokenBuffer = xBufferOut + (group * maxNumTokens + i) * tokenStride;
         uint32_t token = tokenStart + i;
-        sourceIndex[token] = *((uint32_t *)(xTokenBuffer + tokenDim));
+        sourceIndex[token] = i;
         sourceExpert[token] = expert;
         sourceOffset[token] = expertStart + i;
         sourceGroup[token] = dp;
-        sourceToken[token] = i;
+        sourceToken[token] = *((uint32_t *)(xTokenBuffer + tokenDim));
       }
     }
 
@@ -228,7 +228,7 @@ __global__ __launch_bounds__(NUM_WARPS * 32, 1) void dispatchKernel(
       auto expert = sourceExpert[i];
       auto group = expert * numDPGroups + sourceGroup[i];
 
-      std::byte *xTokenBuffer = xBufferOut + (group * maxNumTokens + sourceToken[i]) * tokenStride;
+      std::byte *xTokenBuffer = xBufferOut + (group * maxNumTokens + sourceIndex[i]) * tokenStride;
       std::byte *dstXExpert = expertX + expert * expertXStrideRow;
       float *dstXScaleExpert = expertXScale + expert * expertXScaleStrideCol;
 


### PR DESCRIPTION
Hello,

While reviewing the code, I spotted a potential misuse of the meta-arrays generated during the dispatch phase.
Please find my reasoning below.

[Here](https://github.com/ppl-ai/pplx-kernels/blob/master/csrc/all_to_all/internode_combine.cu#L82) instead of getting sequential indices of tokens sent to this specific expert, the global token numbers will be obtained.
This will result in tokens written in non-contiguous fashion (instead of being compacted at the beginning of the corresponding buffer segment).

Because the target buffer is always large enough to accommodate all buffers, it will not cause a buffer overflow.
And due to the absence (yet?) of data verification, the issue went unnoticed.
