### PR TITLE
relax python versions + fix build linkage error

### DIFF
--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -69,6 +69,7 @@ target_link_libraries(pplx_kernels PUBLIC
     CUDA::cuda_driver
     CUDA::cudart
     nvshmem::nvshmem
+    nvshmem::nvshmem_bootstrap_uid
 )
 set_target_properties(pplx_kernels PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../src/pplx_kernels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "pplx-kernels"
 version = "0.0.1"
 description = "Perplexity CUDA Kernels"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.9"
 
 [build-system]
 requires = ["setuptools>=61.0", "wheel", "torch"]


### PR DESCRIPTION
1. relax python version to >3.9
2. link `nvshmem::nvshmem_bootstrap_uid` , otherwise we have runtime link error.